### PR TITLE
fix: changing operation in $rootOperation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,7 +24,7 @@ model Post {
   title     String
   content   String?
   deleted   Boolean   @default(false)
-  author    User      @relation(fields: [authorId], references: [id])
+  author    User      @relation(fields: [authorId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   authorId  Int
   comments  Comment[]
 }
@@ -34,11 +34,11 @@ model Comment {
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
   content     String
-  author      User      @relation(fields: [authorId], references: [id])
+  author      User      @relation(fields: [authorId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   authorId    Int
-  post        Post?     @relation(fields: [postId], references: [id])
+  post        Post?     @relation(fields: [postId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   postId      Int?
-  repliedTo   Comment?  @relation("replies", fields: [repliedToId], references: [id])
+  repliedTo   Comment?  @relation("replies", fields: [repliedToId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   repliedToId Int?
   replies     Comment[] @relation("replies")
 }
@@ -47,7 +47,7 @@ model Profile {
   id     Int     @id @default(autoincrement())
   bio    String?
   age    Int?
-  user   User    @relation(fields: [userId], references: [id])
+  user   User    @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   userId Int     @unique
   meta   Json?
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,7 +18,7 @@ export type NestedWriteOperation =
   | "updateMany"
   | "delete"
   | "deleteMany";
-  
+
 export type NestedOperation =
   | NestedWriteOperation
   | NestedReadOperation


### PR DESCRIPTION
In $rootOperation the only way to change the operation type is to use the previous client; in $allNestedOperations we are able to manipulate the args that are passed to the query, but in $rootOperation there is no API for switching the operation type of the query function.

Currently if the $rootOperation does not call the query function then the query hangs, this is because we are awaiting the query function in the $allOperations hook generated by withNestedOperations.

Replace the execution of the $rootOperation with a straight call to $rootOperation as we don't need to track any aspect of its execution.