### PR TITLE
feat: avoid multiple types of select calls

### DIFF
--- a/src/lib/utils/extractNestedOperations.ts
+++ b/src/lib/utils/extractNestedOperations.ts
@@ -444,58 +444,6 @@ export function extractRelationReadOperations<
           )
         );
       }
-
-      // push select nested in an include
-      if (operation === "include" && arg.select) {
-        const nestedSelectOperationInfo = {
-          params: {
-            model,
-            operation: "select" as const,
-            args: arg.select,
-            scope: {
-              parentParams: readOperationInfo.params,
-              relations: readOperationInfo.params.scope.relations,
-            },
-            query: params.query,
-          },
-          target: {
-            field: "include" as const,
-            operation: "select" as const,
-            relationName: relation.name,
-            parentTarget,
-          },
-        };
-
-        nestedOperations.push(nestedSelectOperationInfo);
-
-        if (nestedSelectOperationInfo.params.args?.where) {
-          const whereOperationInfo = {
-            target: {
-              operation: "where" as const,
-              relationName: relation.name,
-              readOperation: "select" as const,
-              parentTarget: nestedSelectOperationInfo.target,
-            },
-            params: {
-              model: nestedSelectOperationInfo.params.model,
-              operation: "where" as const,
-              args: nestedSelectOperationInfo.params.args.where,
-              scope: {
-                parentParams: nestedSelectOperationInfo.params,
-                relations: nestedSelectOperationInfo.params.scope.relations,
-              },
-              query: params.query,
-            },
-          };
-          nestedOperations.push(whereOperationInfo);
-          nestedOperations.push(
-            ...extractRelationWhereOperations(
-              whereOperationInfo.params,
-              whereOperationInfo.target
-            )
-          );
-        }
-      }
     });
   });
 

--- a/test/unit/calls.test.ts
+++ b/test/unit/calls.test.ts
@@ -36,8 +36,9 @@ type OperationCall<Model extends Prisma.ModelName> = {
   logicalOperators?: LogicalOperator[];
 };
 
-function nestedParamsFromCall<Model extends Prisma.ModelName,
-ExtArgs extends Types.Extensions.InternalArgs = Types.Extensions.DefaultArgs
+function nestedParamsFromCall<
+  Model extends Prisma.ModelName,
+  ExtArgs extends Types.Extensions.InternalArgs = Types.Extensions.DefaultArgs
 >(
   rootParams: NestedParams<ExtArgs>,
   call: OperationCall<Model>
@@ -2398,24 +2399,6 @@ describe("calls", () => {
         },
         {
           operation: "select",
-          model: "Post",
-          argsPath: "args.include.posts.select",
-          relations: {
-            to: getModelRelation("User", "posts"),
-            from: getModelRelation("Post", "author"),
-          },
-          scope: {
-            operation: "include",
-            model: "Post",
-            argsPath: "args.include.posts",
-            relations: {
-              to: getModelRelation("User", "posts"),
-              from: getModelRelation("Post", "author"),
-            },
-          },
-        },
-        {
-          operation: "select",
           model: "Comment",
           argsPath: "args.include.posts.select.comments",
           relations: {
@@ -2517,33 +2500,6 @@ describe("calls", () => {
             relations: {
               to: getModelRelation("User", "posts"),
               from: getModelRelation("Post", "author"),
-            },
-          },
-        },
-        {
-          operation: "select",
-          model: "Comment",
-          argsPath: "args.include.posts.include.comments.select",
-          relations: {
-            to: getModelRelation("Post", "comments"),
-            from: getModelRelation("Comment", "post"),
-          },
-          scope: {
-            operation: "include",
-            model: "Comment",
-            argsPath: "args.include.posts.include.comments",
-            relations: {
-              to: getModelRelation("Post", "comments"),
-              from: getModelRelation("Comment", "post"),
-            },
-            scope: {
-              operation: "include",
-              model: "Post",
-              argsPath: "args.include.posts",
-              relations: {
-                to: getModelRelation("User", "posts"),
-                from: getModelRelation("Post", "author"),
-              },
             },
           },
         },
@@ -3652,24 +3608,6 @@ describe("calls", () => {
         },
         {
           operation: "select",
-          model: "Post",
-          argsPath: "args.include.posts.select",
-          relations: {
-            to: getModelRelation("User", "posts"),
-            from: getModelRelation("Post", "author"),
-          },
-          scope: {
-            operation: "include",
-            model: "Post",
-            argsPath: "args.include.posts",
-            relations: {
-              to: getModelRelation("User", "posts"),
-              from: getModelRelation("Post", "author"),
-            },
-          },
-        },
-        {
-          operation: "select",
           model: "Comment",
           argsPath: "args.include.posts.select.comments",
           relations: {
@@ -4115,10 +4053,12 @@ describe("calls", () => {
       ],
     },
   ])(
-    "calls middleware with $description",
+    "calls $allNestedOperations with $description",
     async ({ rootParams, nestedCalls = [] }) => {
       const $rootOperation = jest.fn((params) => params.query(params.args));
-      const $allNestedOperations = jest.fn((params) => params.query(params.args));
+      const $allNestedOperations = jest.fn((params) =>
+        params.query(params.args)
+      );
       const allOperations = withNestedOperations({
         $rootOperation,
         $allNestedOperations,

--- a/test/unit/operations.test.ts
+++ b/test/unit/operations.test.ts
@@ -3227,39 +3227,5 @@ describe("operations", () => {
         set(params.args, "data.profile", { delete: false })
       );
     });
-
-    it("replaces existing include with select changed to include", async () => {
-      const allOperations = withNestedOperations({
-        $rootOperation: (params) => {
-          return params.query(params.args);
-        },
-        $allNestedOperations: (params) => {
-          if (params.operation === "select") {
-            return params.query(params.args, "include");
-          }
-
-          return params.query(params.args);
-        },
-      });
-
-      const query = jest.fn((_: any) => Promise.resolve(null));
-      const params = createParams(query, "User", "findUnique", {
-        where: { id: faker.datatype.number() },
-        include: {
-          posts: {
-            select: { deleted: true },
-            include: { author: true },
-          },
-        },
-      });
-
-      await allOperations(params);
-
-      expect(query).toHaveBeenCalledWith(
-        set(params.args, "include.posts", {
-          include: { deleted: true },
-        })
-      );
-    });
   });
 });


### PR DESCRIPTION
Currently there are two scenarios when a select operation type is found:
- When an include has a select within it
- When a select has a relation in it

This means that there is a situation where it is not possible to reason about what to do with a select because the two scenarios look the same based on the available information; both have the include operation as the parent.

BREAKING CHANGE: remove the calls for include selects

Extensions that relied on calls with the "select" operation for select objects within an include will no longer be able to use that call. Instead use the parent "include" operation to modify the selected fields, or use the "select" operation for the relation within that select object.