### PR TITLE
fix: edge runtime support

### DIFF
--- a/src/lib/utils/cloneArgs.ts
+++ b/src/lib/utils/cloneArgs.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "@prisma/client";
-import { cloneDeep, cloneDeepWith } from "lodash";
+import cloneDeep from "lodash/cloneDeep";
+import cloneDeepWith from "lodash/cloneDeepWith";
 
 // Prisma v4 requires that instances of Prisma.NullTypes are not cloned,
 // otherwise it will parse them as 'undefined' and the operation will fail.

--- a/src/lib/utils/execution.ts
+++ b/src/lib/utils/execution.ts
@@ -1,6 +1,6 @@
 import { Types } from "@prisma/client/runtime/library";
 import { DeferredPromise } from "@open-draft/deferred-promise";
-import { omit } from "lodash";
+import omit from "lodash/omit";
 
 import { ExecuteFunction, NestedParams, OperationCall, Target } from "../types";
 import { cloneArgs } from "./cloneArgs";

--- a/src/lib/utils/params.ts
+++ b/src/lib/utils/params.ts
@@ -1,5 +1,9 @@
 import { Types } from "@prisma/client/runtime/library";
-import { merge, omit, get, set, unset } from "lodash";
+import merge from "lodash/merge";
+import omit from "lodash/omit";
+import get from "lodash/get";
+import set from "lodash/set";
+import unset from "lodash/unset";
 
 import {
   OperationCall,

--- a/test/e2e/smoke.test.ts
+++ b/test/e2e/smoke.test.ts
@@ -1,6 +1,5 @@
 import { Post, Prisma, User } from "@prisma/client";
 import faker from "faker";
-import { set } from "lodash";
 
 import { withNestedOperations } from "../../src";
 import client from "./client";

--- a/test/unit/args.test.ts
+++ b/test/unit/args.test.ts
@@ -1,6 +1,6 @@
 import { Prisma } from "@prisma/client";
 import faker from "faker";
-import { set } from "lodash";
+import set from "lodash/set";
 
 import { withNestedOperations } from "../../src";
 import { createParams } from "./helpers/createParams";

--- a/test/unit/calls.test.ts
+++ b/test/unit/calls.test.ts
@@ -1,7 +1,7 @@
 import { Prisma } from "@prisma/client";
 import { Types } from "@prisma/client/runtime/library";
 import faker from "faker";
-import { get } from "lodash";
+import get from "lodash/get";
 
 import { withNestedOperations, NestedParams } from "../../src";
 import { relationsByModel } from "../../src/lib/utils/relations";

--- a/test/unit/operations.test.ts
+++ b/test/unit/operations.test.ts
@@ -1,5 +1,6 @@
 import faker from "faker";
-import { get, set } from "lodash";
+import get from "lodash/get";
+import set from "lodash/set";
 
 import { withNestedOperations } from "../../src";
 import { createParams } from "./helpers/createParams";


### PR DESCRIPTION
closes #6 

By default lodash does not support edge runtimes, however some of thier functions do support edge. Import the lodash functions used directly rather than through the package root to ensure we support edge as well.