### PR TITLE
feat: implement nested `set` operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ returned result, it is the result of the query updated by the returned results f
 The params object passed to the `$allNestedOperations()` function is similar to the params passed to `$allOperations()`.
 It has `args`, `model`, `operation`, and `query` fields, however there are some key differences:
 
-- the `operation` field adds the following options: 'connectOrCreate', 'connect', 'disconnect', 'include', 'select' and 'where'
+- the `operation` field adds the following options: 'connectOrCreate', 'connect', 'disconnect', 'set', 'include', 'select' and 'where'
 - the `query` field takes a second argument, which is the `operation` being performed. This is useful where the type of the nested operation should be changed.
 - there is an additional `scope` field that contains information specific to nested relations:
 
@@ -159,6 +159,7 @@ type Operation =
   | "where"
   | "include"
   | "select"
+  | "set"
   | "connect"
   | "connectOrCreate"
   | "disconnect";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,7 @@ export type NestedWriteOperation =
   | "connectOrCreate"
   | "connect"
   | "disconnect"
+  | "set"
   | "createMany"
   | "updateMany"
   | "delete"

--- a/src/lib/utils/extractNestedOperations.ts
+++ b/src/lib/utils/extractNestedOperations.ts
@@ -40,6 +40,7 @@ export const fieldsByWriteOperation: Record<
   updateMany: ["data"],
   connect: [],
   disconnect: [],
+  set: [],
   delete: [],
   deleteMany: [],
 };

--- a/src/lib/utils/operations.ts
+++ b/src/lib/utils/operations.ts
@@ -17,6 +17,7 @@ export const writeOperations: NestedWriteOperation[] = [
   "delete",
   "deleteMany",
   "disconnect",
+  "set",
   "connect",
   "connectOrCreate",
 ];

--- a/test/unit/operations.test.ts
+++ b/test/unit/operations.test.ts
@@ -2070,6 +2070,81 @@ describe("operations", () => {
         })
       );
     });
+
+    it("can modify nested connect action to be a set", async () => {
+      const allOperations = withNestedOperations({
+        $rootOperation: (params) => {
+          return params.query(params.args);
+        },
+        $allNestedOperations: (params) => {
+          if (params.operation === "connect") {
+            return params.query(params.args, "set");
+          }
+          return params.query(params.args);
+        },
+      });
+
+      const query = jest.fn((_: any) => Promise.resolve(null));
+
+      const params = createParams(query, "User", "update", {
+        where: { id: faker.datatype.number() },
+        data: {
+          email: faker.internet.email(),
+          posts: {
+            connect: {
+              id: faker.datatype.number(),
+            },
+          },
+        },
+      });
+
+      await allOperations(params);
+
+      expect(query).toHaveBeenCalledWith(
+        set(params.args, "data.posts", {
+          set: params.args.data.posts.connect,
+        })
+      );
+    });
+  });
+
+  describe("disconnect", () => {
+    it("can modify nested disconnect action to be a set", async () => {
+      const allOperations = withNestedOperations({
+        $rootOperation: (params) => {
+          return params.query(params.args);
+        },
+        $allNestedOperations: (params) => {
+          if (params.operation === "disconnect") {
+            return params.query(params.args, "set");
+          }
+          return params.query(params.args);
+        },
+      });
+
+      const query = jest.fn((_: any) => Promise.resolve(null));
+
+      const params = createParams(query, "User", "update", {
+        where: { id: faker.datatype.number() },
+        data: {
+          email: faker.internet.email(),
+          posts: {
+            disconnect: [
+              { id: faker.datatype.number() },
+              { id: faker.datatype.number() },
+            ],
+          },
+        },
+      });
+
+      await allOperations(params);
+
+      expect(query).toHaveBeenCalledWith(
+        set(params.args, "data.posts", {
+          set: params.args.data.posts.disconnect,
+        })
+      );
+    });
   });
 
   describe("connectOrCreate", () => {
@@ -2345,6 +2420,245 @@ describe("operations", () => {
       expect(query).toHaveBeenCalledWith(
         set(params.args, "data.posts", {
           connect: params.args.data.posts.connectOrCreate.where,
+        })
+      );
+    });
+
+    it("can modify nested connectOrCreate action to be a set", async () => {
+      const allOperations = withNestedOperations({
+        $rootOperation: (params) => {
+          return params.query(params.args);
+        },
+        $allNestedOperations: (params) => {
+          if (params.operation === "connectOrCreate") {
+            return params.query(params.args.where, "set");
+          }
+          return params.query(params.args);
+        },
+      });
+
+      const query = jest.fn((_: any) => Promise.resolve(null));
+
+      const params = createParams(query, "User", "update", {
+        where: { id: faker.datatype.number() },
+        data: {
+          email: faker.internet.email(),
+          posts: {
+            connectOrCreate: {
+              where: { id: faker.datatype.number() },
+              create: {
+                id: faker.datatype.number(),
+                title: faker.lorem.sentence(),
+              },
+            },
+          },
+        },
+      });
+
+      await allOperations(params);
+
+      expect(query).toHaveBeenCalledWith(
+        set(params.args, "data.posts", {
+          set: params.args.data.posts.connectOrCreate.where,
+        })
+      );
+    });
+  });
+
+  describe("set", () => {
+    it("can modify nested set action to be a connect", async () => {
+      const allOperations = withNestedOperations({
+        $rootOperation: (params) => {
+          return params.query(params.args);
+        },
+        $allNestedOperations: (params) => {
+          if (params.operation === "set") {
+            return params.query(params.args, "connect");
+          }
+          return params.query(params.args);
+        },
+      });
+
+      const query = jest.fn((_: any) => Promise.resolve(null));
+
+      const params = createParams(query, "User", "update", {
+        where: { id: faker.datatype.number() },
+        data: {
+          email: faker.internet.email(),
+          posts: {
+            set: [
+              { id: faker.datatype.number() },
+              { id: faker.datatype.number() },
+            ],
+          },
+        },
+      });
+
+      await allOperations(params);
+
+      expect(query).toHaveBeenCalledWith(
+        set(params.args, "data.posts", {
+          connect: params.args.data.posts.set,
+        })
+      );
+    });
+
+    it("can modify nested set action to be a disconnect", async () => {
+      const allOperations = withNestedOperations({
+        $rootOperation: (params) => {
+          return params.query(params.args);
+        },
+        $allNestedOperations: (params) => {
+          if (params.operation === "set") {
+            return params.query(params.args, "disconnect");
+          }
+          return params.query(params.args);
+        },
+      });
+
+      const query = jest.fn((_: any) => Promise.resolve(null));
+
+      const params = createParams(query, "User", "update", {
+        where: { id: faker.datatype.number() },
+        data: {
+          email: faker.internet.email(),
+          posts: {
+            set: [
+              { id: faker.datatype.number() },
+              { id: faker.datatype.number() },
+            ],
+          },
+        },
+      });
+
+      await allOperations(params);
+
+      expect(query).toHaveBeenCalledWith(
+        set(params.args, "data.posts", {
+          disconnect: params.args.data.posts.set,
+        })
+      );
+    });
+
+    it("can modify nested set action to be a create", async () => {
+      const allOperations = withNestedOperations({
+        $rootOperation: (params) => {
+          return params.query(params.args);
+        },
+        $allNestedOperations: (params) => {
+          if (params.operation === "set") {
+            return params.query(params.args, "create");
+          }
+          return params.query(params.args);
+        },
+      });
+
+      const query = jest.fn((_: any) => Promise.resolve(null));
+
+      const params = createParams(query, "User", "update", {
+        where: { id: faker.datatype.number() },
+        data: {
+          email: faker.internet.email(),
+          posts: {
+            set: [
+              { id: faker.datatype.number(), title: faker.lorem.sentence() },
+              { id: faker.datatype.number(), title: faker.lorem.sentence() },
+            ],
+          },
+        },
+      });
+
+      await allOperations(params);
+
+      expect(query).toHaveBeenCalledWith(
+        set(params.args, "data.posts", {
+          create: params.args.data.posts.set,
+        })
+      );
+    });
+
+    it("can modify nested set action to be a connectOrCreate", async () => {
+      const allOperations = withNestedOperations({
+        $rootOperation: (params) => {
+          return params.query(params.args);
+        },
+        $allNestedOperations: (params) => {
+          if (params.operation === "set") {
+            return params.query({
+              create: params.args,
+              where: params.args
+            }, "connectOrCreate");
+          }
+          return params.query(params.args);
+        },
+      });
+
+      const query = jest.fn((_: any) => Promise.resolve(null));
+
+      const params = createParams(query, "User", "update", {
+        where: { id: faker.datatype.number() },
+        data: {
+          email: faker.internet.email(),
+          posts: {
+            set: [
+              { id: faker.datatype.number() },
+              { id: faker.datatype.number() },
+            ],
+          },
+        },
+      });
+
+      await allOperations(params);
+
+      expect(query).toHaveBeenCalledWith(
+        set(params.args, "data.posts", {
+          connectOrCreate: [
+            {
+              where: params.args.data.posts.set[0],
+              create: params.args.data.posts.set[0],
+            },
+            {
+              where: params.args.data.posts.set[1],
+              create: params.args.data.posts.set[1],
+            },
+          ],
+        })
+      );
+    });
+
+    it("can modify nested set action to be a delete", async () => {
+      const allOperations = withNestedOperations({
+        $rootOperation: (params) => {
+          return params.query(params.args);
+        },
+        $allNestedOperations: (params) => {
+          if (params.operation === "set") {
+            return params.query(params.args, "delete");
+          }
+          return params.query(params.args);
+        },
+      });
+
+      const query = jest.fn((_: any) => Promise.resolve(null));
+
+      const params = createParams(query, "User", "update", {
+        where: { id: faker.datatype.number() },
+        data: {
+          email: faker.internet.email(),
+          posts: {
+            set: [
+              { id: faker.datatype.number() },
+              { id: faker.datatype.number() },
+            ],
+          },
+        },
+      });
+
+      await allOperations(params);
+
+      expect(query).toHaveBeenCalledWith(
+        set(params.args, "data.posts", {
+          delete: params.args.data.posts.set,
         })
       );
     });


### PR DESCRIPTION
Implements the nested `set` operation: https://www.prisma.io/docs/orm/prisma-client/queries/relation-queries#disconnect-all-related-records.

fixes #18 